### PR TITLE
Enable `size_t_is_usize`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -40,6 +40,7 @@ fn main() {
         .default_enum_style(EnumVariation::Rust {
             non_exhaustive: false,
         })
+        .size_t_is_usize(true)
         .generate()
         .expect("Unable to generate bindings");
 


### PR DESCRIPTION
This is a breaking change.

`bindgen` switched the default output for parameters with the `size_t` C type to `u32`/`u64` depending on the target platform. Per https://github.com/rust-lang/rust-bindgen/issues/1671, the old behaviour where `size_t` would just output `usize` is not _technically_ correct, because the C standard has a slightly different definition for `size_t`.

AFAIK it _is_ correct for all platforms that Node.js supports though. bindgen added a toggle to opt back in to the old behaviour. Since bindgen had been doing this for years without issue, I think we're safe 🤔 
