### PR TITLE
Make `key_filter`, `property_attributes` bitfields

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -40,6 +40,8 @@ fn main() {
         .default_enum_style(EnumVariation::Rust {
             non_exhaustive: false,
         })
+        .bitfield_enum("napi_key_filter")
+        .bitfield_enum("napi_property_attributes")
         .size_t_is_usize(true)
         .generate()
         .expect("Unable to generate bindings");


### PR DESCRIPTION
These enums are supposed to be combined using `|`, but the "rustified"
enum configuration doesn't allow it. Bindgen has a bitfield enum feature
which _does_ allow `|`-ing values.

N-API currently includes two enums used as bitfields:
[`napi_key_filter`][] and [`napi_property_attributes`][].

With this patch you can do things like
```rust
use nodejs_sys::napi_key_filter;

napi_key_filter::napi_key_enumerable | napi_key_filter::napi_key_skip_symbols
```
to create a key filter for `napi_get_all_property-names` that only returns
enumerable string keys.

[`napi_key_filter`]: https://nodejs.org/api/n-api.html#n_api_napi_key_filter
[`napi_property_attributes`]: https://nodejs.org/api/n-api.html#n_api_napi_property_attributes