### PR TITLE
N-API v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Node v14.12.0
+
+affected files:
+* [src/js_native_api.h](https://github.com/nodejs/node/blob/v14.12.0/src/js_native_api.h)
+* [src/js_native_api_types.h](https://github.com/nodejs/node/blob/v14.12.0/src/js_native_api_types.h)
+
+upstream changelog:
+* [ca1181615e](https://github.com/nodejs/node/commit/ca1181615e961ec948587aa6f8b7e46efd7cbd71) n-api: create N-API version 7
+* [7f3b2b2a1f](https://github.com/nodejs/node/commit/7f3b2b2a1f2b2fa25adf9c4ea261f2a99ddd74aa) n-api: add more property defaults
+
 # v0.7.0 `key_filter` and `property_attributes` are now bitfields
 
 These enums are supposed to be combined using `|`, but the "rustified"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Features
 Different API versions may be selected via feature-flag. See the [N-API Version Matrix](https://nodejs.org/dist/latest-v14.x/docs/api/n-api.html#n_api_n_api_version_matrix) for details.
 
 - `napi_v5` supported by all [actively maintained](https://nodejs.org/en/about/releases/) NodeJS releases
-- `napi_v6` requires at least `v13.7.0`, this is the **default** (if no flag is given)
+- `napi_v6` supported by all [actively maintained](https://nodejs.org/en/about/releases/) NodeJS releases
+- `napi_v7` requires at least `v14.12.0`, this is the **default** (if no flag is given)
 - the experimental N-API features may be enabled via feature flag `experimental` (*off* by default)
 
 Updates

--- a/build.rs
+++ b/build.rs
@@ -18,7 +18,9 @@ impl ExtendedBuilder for Builder {
     }
 
     fn set_napi_version(self) -> Builder {
-        if cfg!(feature = "napi_v6") {
+        if cfg!(feature = "napi_v7") {
+            self.clang_arg("-D NAPI_VERSION=7")
+        } else if cfg!(feature = "napi_v6") {
             self.clang_arg("-D NAPI_VERSION=6")
         } else if cfg!(feature = "napi_v5") {
             self.clang_arg("-D NAPI_VERSION=5")

--- a/update-node-submodule.sh
+++ b/update-node-submodule.sh
@@ -42,7 +42,7 @@ fi
 
 git checkout "$MOST_RECENT_VERSION"
 
-if ! grep "NAPI_VERSION  6" src/node_version.h; then
+if ! grep "NAPI_VERSION  7" src/node_version.h; then
   echo "Detected new NAPI_VERSION. Refusing to auto-update. Please add feature-flag etc."
   exit 1
 fi


### PR DESCRIPTION
Node.js v `14.12.0` introduced N-API version 7.
See: 
https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V14.md#14.12.0
I tried to update this crate to support N-API v7.